### PR TITLE
FIX: Conexión del % de victorias

### DIFF
--- a/bombava-frontend/src/componentes/CartelPerfil.jsx
+++ b/bombava-frontend/src/componentes/CartelPerfil.jsx
@@ -43,7 +43,7 @@ function CartelPerfil({ usuario, editando, nuevoNombre, setNuevoNombre, nuevoEma
           </p>
           <p><strong>Reputación:</strong> {usuario.elo_rating} ELO</p>
           {/*Habría que completar con las victorias del jugador, ahora lo he puesto con 0*/}
-          <p><strong>Victorias:</strong> {"0"}%</p>
+          <p><strong>Victorias:</strong> {usuario.winRate}%</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Añadido el % de victorias al perfil.
Antes estaba con 0% por defecto, ahora esta conectado con la API(lo acaban de implementar).

Closes #107 