### PR TITLE
Solución del rango de ataque

### DIFF
--- a/bombava-frontend/src/componentes/barco/movimientosBarco.js
+++ b/bombava-frontend/src/componentes/barco/movimientosBarco.js
@@ -310,13 +310,17 @@ export const useMovimientosBarco = (barcosIniciales, { mapa, setModoAtaque }) =>
             return true;
         }
 
-        // Calculamos el centro del barco atacante para medir la distancia desde ahí
-        const { centroX, centroY } = calcularCentroBarco(atacante);
+        // Comprobamos si el objetivo está en el rango de alguna de las celdas del barco
+        let enRango = false;
+        for (const celda of atacante.celdas) {
+            const distancia = Math.abs(celda.x - targetX) + Math.abs(celda.y - targetY);
+            if (distancia <= arma.rango) {
+                enRango = true;
+                break;
+            }
+        }
 
-        // Comprobamos el rango usando la distancia Manhattan (distancia en línea recta).
-        const distancia = Math.abs(centroX - targetX) + Math.abs(centroY - targetY);
-
-        if (distancia > arma.rango) {
+        if (!enRango) {
             // Indicamos que ese ataque esta fuera del rango de ataque.
             notification.toast("Fuera de rango", 'warning');
 

--- a/bombava-frontend/src/componentes/mapa/Mapa.jsx
+++ b/bombava-frontend/src/componentes/mapa/Mapa.jsx
@@ -101,10 +101,10 @@ const Mapa = ({
     
     // Calculamos el rango desde todas las celdas del barco
     const celdasDelBarco = atacante.celdas;
-    for (const celdaOcupada of celdasDelBarco) {
-      const celdasEnRangoDesdeCelda = calcularCeldasEnRangoManhattan(celdaOcupada.x, celdaOcupada.y, arma.rango);
+    for (const celdaBarco of celdasDelBarco) {
+      const celdasEnRangoDesdeCelda = calcularCeldasEnRangoManhattan(celdaBarco.x, celdaBarco.y, arma.rango);
       
-      // Por cada celda en rango desde la celda ocupada, la agregamos al set
+      // Las celdas en rango desde la celda del barco que se esta comprobando las agregamos al set
       for (const celda of celdasEnRangoDesdeCelda) {
         celdasEnRango.add(celda);
       }

--- a/bombava-frontend/src/componentes/mapa/Mapa.jsx
+++ b/bombava-frontend/src/componentes/mapa/Mapa.jsx
@@ -144,7 +144,7 @@ const Mapa = ({
       }
 
       {/* Capa de Niebla de Guerra sobre el resto de elementos */}
-      <Niebla celdasVisibles={celdasVisibles} />
+      <Niebla celdasVisibles={celdasVisibles} celdasEnRango={celdasEnRango} />
     </div>
   );
 };

--- a/bombava-frontend/src/componentes/mapa/Mapa.jsx
+++ b/bombava-frontend/src/componentes/mapa/Mapa.jsx
@@ -1,8 +1,7 @@
 import Tablero from '../tablero/Tablero.jsx';
 import Barco from '../barco/Barco.jsx';
 import Proyectil from '../proyectil/Proyectil.jsx'
-import { calcularCentroBarco, calcularCeldasBarco } from '../barco/movimientosBarco.js';
-import { calcularCeldasVisiblesFlota } from '../../utils/visionUtils.js';
+import { calcularCeldasVisiblesFlota, calcularCeldasEnRangoManhattan } from '../../utils/visionUtils.js';
 import Niebla from './Niebla.jsx';
 import { TAMANO_TABLERO, ARMAS } from '../../utils/constantes.js';
 import '../../styles/Mapa.css';
@@ -94,27 +93,24 @@ const Mapa = ({
     const atacante = barcos.find(b => b.id == barcoSeleccionado);
     if (!atacante) return new Set();
 
-    // Calculamos el centro del barco seleccionado
-    const { centroX, centroY } = calcularCentroBarco(atacante);
-
     const arma = ARMAS[armaSeleccionada];
     if (!arma) return new Set();
 
     // Calculamos las celdas en el rango de ataque, y las agregamos a un Set(tabla hash)
-    const celdas = new Set();
-    for (let x = centroX - arma.rango; x <= centroX + arma.rango; x++) {
-      for (let y = centroY - arma.rango; y <= centroY + arma.rango; y++) {
-        // Si la celda está fuera del tablero, no la agregamos
-        if (x >= 0 && x < TAMANO_TABLERO && y >= 0 && y < TAMANO_TABLERO) {
-          const distancia = Math.abs(centroX - x) + Math.abs(centroY - y);
-          // Si la celda está fuera del rango, no la agregamos
-          if (distancia <= arma.rango) {
-            celdas.add(`${x},${y}`);
-          }
-        }
+    const celdasEnRango = new Set();
+    
+    // Calculamos el rango desde todas las celdas del barco
+    const celdasDelBarco = atacante.celdas;
+    for (const celdaOcupada of celdasDelBarco) {
+      const celdasEnRangoDesdeCelda = calcularCeldasEnRangoManhattan(celdaOcupada.x, celdaOcupada.y, arma.rango);
+      
+      // Por cada celda en rango desde la celda ocupada, la agregamos al set
+      for (const celda of celdasEnRangoDesdeCelda) {
+        celdasEnRango.add(celda);
       }
     }
-    return celdas;
+    
+    return celdasEnRango;
   };
 
   const celdasEnRango = calcularCeldasEnRango();

--- a/bombava-frontend/src/componentes/mapa/Niebla.jsx
+++ b/bombava-frontend/src/componentes/mapa/Niebla.jsx
@@ -10,17 +10,19 @@ import '../../styles/Niebla.css';
  * 
  * @param {Set<string>} celdasVisibles - Conjunto de coordenadas "x,y" que son visibles.
  */
-const Niebla = ({ celdasVisibles }) => {
+const Niebla = ({ celdasVisibles, celdasEnRango }) => {
   const grid = [];
 
   for (let y = 0; y < TAMANO_TABLERO; y++) {
     for (let x = 0; x < TAMANO_TABLERO; x++) {
-      const esVisible = celdasVisibles.has(`${x},${y}`);
+      const coordenadas = `${x},${y}`;
+      const esVisible = celdasVisibles.has(coordenadas);
+      const enRangoAtaque = celdasEnRango?.has(coordenadas);
       
       grid.push(
         <div 
-          key={`${x},${y}`} 
-          className={`celda-niebla ${esVisible ? 'visible' : 'oculta'}`}
+          key={coordenadas} 
+          className={`celda-niebla ${esVisible ? 'visible' : 'oculta'} ${enRangoAtaque ? 'en-rango-ataque-niebla' : ''}`}
           style={{
             gridColumn: x + 1,
             gridRow: y + 1

--- a/bombava-frontend/src/pantallas/Combate.jsx
+++ b/bombava-frontend/src/pantallas/Combate.jsx
@@ -418,19 +418,19 @@ function Combate() {
     useEffect(() => {
         //Recibe la señal de que han pedido pausar con el nombre del usuario que la ha aceptado
         const handlePauseRequested = (payload) => {
-            notification.info(payload.from + " ha pedido pausar.");
+            notification.top(payload.from + " ha pedido pausar.", 'info');
             setCuadroDecidirSiPausarVisible(true);
         };
 
         // Se ha pausado la partida, o yo he aceptado o el otro ha aceptado pausar
         const handleMatchPaused = (payload) => {
-            notification.info(payload.message);
+            notification.top(payload.message, 'info');
             navigate('/menuInicial');
         };
 
         // Si rechaza el otro pausar la partida
         const handlePauseReject = (payload) => {
-            notification.info(payload.message);
+            notification.top(payload.message, 'info');
             
         };
 

--- a/bombava-frontend/src/styles/Combate.css
+++ b/bombava-frontend/src/styles/Combate.css
@@ -89,9 +89,10 @@
     flex-direction: column;
     align-items: center;
     background: linear-gradient(to bottom, #b68d68, #8b5e3c);
-    border-radius: 10px;
+    border: 2px solid #5d4037;
+    border-radius: 5%;
     padding: 1rem;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+    box-shadow: 0px 3px 0px #3e2723;
     align-self: center;
     flex: 1;
     min-width: 250px;
@@ -104,7 +105,7 @@
     box-sizing: border-box;
     display: flex;
     justify-content: center;
-    margin-top: 120px;
+    margin-top: 40px;
 }
 
 .recursos-contendor {

--- a/bombava-frontend/src/styles/Niebla.css
+++ b/bombava-frontend/src/styles/Niebla.css
@@ -24,3 +24,22 @@
 .celda-niebla.oculta {
   opacity: 1;
 }
+
+.celda-niebla.oculta.en-rango-ataque-niebla {
+  background-color: #5c3c3c;
+  animation: animacionCeldasNiebla 2s infinite;
+}
+
+@keyframes animacionCeldasNiebla {
+  0% {
+    filter: brightness(1.1);
+  }
+
+  50% {
+    filter: brightness(1.3);
+  }
+
+  100% {
+    filter: brightness(1.1);
+  }
+}

--- a/bombava-frontend/src/styles/configuracion_flota/SelectorBarcos.css
+++ b/bombava-frontend/src/styles/configuracion_flota/SelectorBarcos.css
@@ -13,7 +13,7 @@
   padding: 12px;
   color: #e0d0b0;
   font-family: 'Georgia';
-  min-height: 160px;
+  height: 200px;
   display: flex;
   flex-direction: column;
   font-size: 0.9rem;


### PR DESCRIPTION
Problemas solucionados:
* Ahora el rango de ataque se ve sobre la niebla.
* El rango de ataque se calcula con la distancia de Manhattan desde todas las casillas y no solo desde el centro.
* EL bug al configurar la flota esta solucionado. El bug consistía en que al seleccionar un barco los componentes de la pantalla se movían de posición.
* Solución de unas notificaciones que seguían teniendo el formato antiguo.

Closes: #115 
Closes #110 
Closes #83 